### PR TITLE
ipns helper: map large objects to unixfs objects

### DIFF
--- a/core/push.go
+++ b/core/push.go
@@ -15,6 +15,7 @@ import (
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	mh "gx/ipfs/QmU9a9NV9RdPNwZQDYd5uKsm6N6LJLSvLbywDDYFbaaC6P/go-multihash"
+	cid "gx/ipfs/QmNp85zy9RLrQ5oQD4hPyS39ezrrXpcaa7R4Y9kxdWQLLQ/go-cid"
 )
 
 type Push struct {
@@ -27,6 +28,8 @@ type Push struct {
 	log     *log.Logger
 	tracker *Tracker
 	repo    *git.Repository
+
+	NewNode func(hash *cid.Cid, data []byte) error
 }
 
 func NewPush(gitDir string, tracker *Tracker, repo *git.Repository) *Push {
@@ -113,6 +116,12 @@ func (p *Push) doWork() error {
 
 		if expectedCid.String() != res {
 			return fmt.Errorf("CIDs don't match: expected %s, got %s", expectedCid.String(), res)
+		}
+
+		if p.NewNode != nil {
+			if err := p.NewNode(expectedCid, raw); err != nil {
+				return err
+			}
 		}
 
 		p.processLinks(raw)


### PR DESCRIPTION
This creates `/objects` within the repo which contains mapping GitCid -> UnixfsCid.

Example - https://ipfs.io/ipfs/QmPRUu8HPrmSkAGfhPQbdUxe1we8N5HeGMdWpUzxmJd4FR

This is a workaround for object size limit (which is a bit less than 4mb)